### PR TITLE
Add typedef and treat enum as string value as default

### DIFF
--- a/lib/genTS.js
+++ b/lib/genTS.js
@@ -199,7 +199,7 @@ exports.default = (ast, Request = "./request") => {
     if (ast.union) {
         code += structsLikeHandler(ast.union);
     }
-    if (ast.service) {
+    if (Request && ast.service) {
         code += servicesHandler(ast.service);
     }
     if (ast.service) {

--- a/lib/genTS.js
+++ b/lib/genTS.js
@@ -82,6 +82,13 @@ exports.default = (ast, Request = "./request") => {
         });
         return newConsts;
     };
+    const typedefsHandler = (typedefs) => {
+        let newTypedefs = "";
+        Object.keys(typedefs).forEach(key => {
+            newTypedefs += `${NEW_LINE}export type ${key} = ${valueTypeTransformer(typedefs[key]["type"])}; ${NEW_LINE}`;
+        });
+        return newTypedefs;
+    };
     const enumsHandler = (enums) => {
         let newEnums = "";
         Object.keys(enums).forEach(key => {
@@ -90,13 +97,11 @@ exports.default = (ast, Request = "./request") => {
         return newEnums;
     };
     const enumHandler = (name, items) => {
-        let lastValue = -1;
         let code = `${NEW_LINE}export enum ${name} {`;
         items.forEach((item, index) => {
             if (item["value"] === undefined) {
-                item["value"] = lastValue + 1;
+                item["value"] = `"${item["name"]}"`;
             }
-            lastValue = item["value"];
             code += `${NEW_LINE}${item["name"]} = ${item["value"]}`;
             if (index < items.length - 1) {
                 code += ",";
@@ -178,6 +183,9 @@ exports.default = (ast, Request = "./request") => {
     }
     if (ast.const) {
         code += constsHandler(ast.const);
+    }
+    if (ast.typedef) {
+        code += typedefsHandler(ast.typedef);
     }
     if (ast.enum) {
         code += enumsHandler(ast.enum);

--- a/src/genTS.ts
+++ b/src/genTS.ts
@@ -288,7 +288,7 @@ export default (ast: any, Request = "./request"): string => {
     }
 
     // service -> functions
-    if (ast.service) {
+    if (Request && ast.service) {
         code += servicesHandler(ast.service);
     }
 

--- a/src/genTS.ts
+++ b/src/genTS.ts
@@ -138,13 +138,13 @@ export default (ast: any, Request = "./request"): string => {
     };
 
     const enumHandler = (name, items: object[]): string => {
-        let lastValue = -1;
+        // let lastValue = -1;
         let code = `${NEW_LINE}export enum ${name} {`;
         items.forEach((item, index) => {
             if (item["value"] === undefined) {
-                item["value"] = lastValue + 1;
+                item["value"] = `"${item["name"]}"`;
             }
-            lastValue = item["value"];
+            // lastValue = item["value"];
             code += `${NEW_LINE}${item["name"]} = ${item["value"]}`;
             if (index < items.length - 1) {
                 code += ",";

--- a/src/genTS.ts
+++ b/src/genTS.ts
@@ -129,6 +129,16 @@ export default (ast: any, Request = "./request"): string => {
         return newConsts;
     };
 
+    const typedefsHandler = (typedefs: object[]): string => {
+        let newTypedefs = "";
+        Object.keys(typedefs).forEach(key => {
+            newTypedefs += `${NEW_LINE}export type ${key} = ${valueTypeTransformer(
+                typedefs[key]["type"]
+            )}; ${NEW_LINE}`;
+        });
+        return newTypedefs;
+    };
+
     const enumsHandler = (enums: object[]): string => {
         let newEnums = "";
         Object.keys(enums).forEach(key => {
@@ -250,6 +260,11 @@ export default (ast: any, Request = "./request"): string => {
     // const -> const
     if (ast.const) {
         code += constsHandler(ast.const);
+    }
+
+    // typedef -> type
+    if (ast.typedef) {
+        code += typedefsHandler(ast.typedef)
     }
 
     // enum -> interface


### PR DESCRIPTION
I added support for typedefs for #1 

I also needed to treat enum's as strings by default rather than as number, but that is only because the thrift library I'm using exports strings instead of numbers. You don't need to accept that change if it breaks users of this package. I could instead add a cli flag to change how `enum` outputs.